### PR TITLE
Supports multi-level menu

### DIFF
--- a/SystemTray/TrayIcon.cs
+++ b/SystemTray/TrayIcon.cs
@@ -179,7 +179,7 @@ namespace Utils
 
             IntPtr hMenu = WinAPI.CreatePopupMenu();
             if (hMenu == IntPtr.Zero) return;
-            
+
             Dictionary<string, MultiLevelMenuItem> items = new();
             Queue<MultiLevelMenuItem> menus = new();
             foreach (var info in ActionMappings)
@@ -201,7 +201,7 @@ namespace Utils
                         crt.Name = p;
                         items.Add(crtPath, crt);
                     }
-            
+
                     if (parent == null)
                     {
                         if (menus.Contains(crt) == false)
@@ -214,10 +214,10 @@ namespace Utils
                         crt.Parent = parent;
                         parent.Children.Add(crt);
                     }
-            
+
                     parent = crt;
                 }
-            
+
                 if (parent == null)
                 {
                     Debug.LogError($"Wrong Path: {info.Value}");
@@ -227,19 +227,19 @@ namespace Utils
                     parent.ID = info.Key;
                 }
             }
-            
+
             while (menus.Count > 0)
             {
                 var crt = menus.Dequeue();
-            
+
                 var parent = crt.Parent?.MenuID ?? hMenu;
-            
+
                 if (crt.Name == SEPARATOR)
                 {
                     WinAPI.AppendMenu(parent, MF_SEPARATOR, 0, null);
                     continue;
                 }
-            
+
                 if (crt.Children.Count > 0)
                 {
                     IntPtr subMenu = WinAPI.CreatePopupMenu();
@@ -248,11 +248,11 @@ namespace Utils
                     {
                         menus.Enqueue(child);
                     }
-                    WinAPI.AppendMenu(parent,  MF_STRING|MF_POPUP, (uint)subMenu, crt.Name);
+                    WinAPI.AppendMenu(parent, MF_STRING | MF_POPUP, (uint)subMenu, crt.Name);
                 }
                 else
                 {
-                    WinAPI.AppendMenu(parent,  MF_STRING, crt.ID, crt.Name);
+                    WinAPI.AppendMenu(parent, MF_STRING, crt.ID, crt.Name);
                 }
             }
 


### PR DESCRIPTION
Multi-level menu with ‘\’ cut paths.
Example:
<img width="470" alt="Snipaste_2025-06-23_17-31-31" src="https://github.com/user-attachments/assets/4f81970f-4e91-413c-8717-9ba57d8a2228" />
<img width="217" alt="Snipaste_2025-06-23_17-31-10" src="https://github.com/user-attachments/assets/0f3ec371-5b75-480b-9fe0-9d836c9567b3" />
