### PR TITLE
Add IL2CPP compatibility

### DIFF
--- a/SystemTray/TrayIcon.cs
+++ b/SystemTray/TrayIcon.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using UnityEngine;
+using AOT;
 
 namespace Utils
 {
@@ -182,6 +183,7 @@ namespace Utils
             WinAPI.DestroyMenu(hMenu);
         }
 
+        [MonoPInvokeCallback(typeof(WndProcDelegate))]
         private static IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
         {
             switch (msg)

--- a/SystemTray/TrayIcon.cs
+++ b/SystemTray/TrayIcon.cs
@@ -1,8 +1,8 @@
+using AOT;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using UnityEngine;
-using AOT;
 
 namespace Utils
 {

--- a/SystemTray/WinAPI.cs
+++ b/SystemTray/WinAPI.cs
@@ -73,6 +73,7 @@ namespace Utils
         }
 
         // Delegate Definition
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)] // Ensures the WndProc calling convention (Winapi)
         private delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
     }
 }

--- a/SystemTray/WinAPI.cs
+++ b/SystemTray/WinAPI.cs
@@ -73,7 +73,7 @@ namespace Utils
         }
 
         // Delegate Definition
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)] // Ensures the WndProc calling convention (Winapi)
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)] // Ensure WndProc calling convention (Winapi)
         private delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
     }
 }


### PR DESCRIPTION
This repository works perfectly if you use Mono compilation, but if you try to use IL2CPP it's going to fail, probably with the error message of "Fix marshal managed method NotSupportedException".

This PR fixes that issue.

